### PR TITLE
added matrix well-known files

### DIFF
--- a/.well-known/matrix/client
+++ b/.well-known/matrix/client
@@ -1,0 +1,1 @@
+{ "m.homeserver": { "base_url": "https://matrix.tugslug.org/" } }

--- a/.well-known/matrix/server
+++ b/.well-known/matrix/server
@@ -1,0 +1,1 @@
+{ "m.server": "matrix.tugslug.org:443" }

--- a/_config.yml
+++ b/_config.yml
@@ -7,5 +7,6 @@ baseurl:
 source_code: https://github.com/nobodywasishere/tgslug
 
 exclude: []
+include: [".well-known"]
 
 future: true


### PR DESCRIPTION
Files required to use tugslug.org as the matrix homeserver while being hosted on matrix.tugslug.org